### PR TITLE
Include more patches

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,11 +53,8 @@ if (searchParams.has("labels")) {
 } else {
     filters = [
         "is:open",
-        "-status:failure",
         "archived:false",
-        "-label:bugzilla/invalid-bug",
         "-label:do-not-merge/work-in-progress",
-        "-label:do-not-merge/hold",
     ];
 }
 const bzRegex = /^Bug #?([0-9]+): ?(.*)/;

--- a/index.html
+++ b/index.html
@@ -148,17 +148,7 @@ function render_repo(repo, items) {
 }
 
 function should_skip(item) {
-    var has_lgtm = false;
-    var has_approved = false;
-    for (let lbl of item.labels) {
-        if (lbl.name == "lgtm") {
-            has_lgtm = true;
-        }
-        if (lbl.name == "approved") {
-            has_approved = true;
-        }
-    }
-    return has_lgtm && has_approved;
+    return false;
 }
 
 function render_response(items) {


### PR DESCRIPTION
Sometimes the most important stuff to know about is something that can't
merge.

* Patches routinely have a hold on them when they're looking for one
  more review.
* Optional CI jobs routinely fail.
* If a patch has an invalid bug label then it needs *more* attention,
  not less.

The number of simultaneous open reviews is not large and the labels are
displayed, so it is easy enough to mentally filter out PRs that have
various labels, but much harder to discover PRs that don't appear in the
list.